### PR TITLE
Fixed typos and grammatical errors in documentation

### DIFF
--- a/pages/devs/get-started/basic-usage.mdx
+++ b/pages/devs/get-started/basic-usage.mdx
@@ -8,10 +8,10 @@ Despite the complexities involved in the setup and operation of different partic
 
 Interacting with the Allora Network also involves querying data of existing topics on-chain. This can be efficiently done using the Allorad CLI tool. The CLI tool provides a command-line interface to interact with the network, enabling users to retrieve on-chain data seamlessly.
 
-Follow the tutorial [here](/devs/consumers/onchain-query-existing-data) to learn how to query an inference onchain using the `allorad` CLI tool.
+Follow the tutorial [here](/devs/consumers/onchain-query-existing-data) to learn how to query an inference on-chain using the `allorad` CLI tool.
 
 ## Delegating Stake to a Reputer
 
-Users can delegate their stake to a reputor, contributing to the network's overall health and performance. This involves a basic understanding of staking mechanisms and can be done through the `allorad` CLI tool.
+Users can delegate their stake to a reputer, contributing to the network's overall health and performance. This involves a basic understanding of staking mechanisms and can be done through the `allorad` CLI tool.
 
 Follow the tutorial [here](/devs/reference/allorad#delegate-stake-to-a-reputer-for-a-topic) to learn how to delegate your stake to a reputer.

--- a/pages/home/explore.mdx
+++ b/pages/home/explore.mdx
@@ -63,4 +63,4 @@ Here we'll help you find exactly what you're looking for.
 
 ## Questions?
 
-Join the Allora Network [Community](/community/contribute) to ask for help, help improve Allora, or showcase what you built with Allora.
+Join the Allora Network [Community](/community/contribute) to ask for support, help improve Allora, or showcase what you built with Allora.

--- a/pages/home/layers/consensus/reputers.mdx
+++ b/pages/home/layers/consensus/reputers.mdx
@@ -4,8 +4,8 @@ Reputers are rewarded based on their accuracy relative to consensus (formed by a
 
 ## Problem: Runaway Centralization
 1. **Stake-Weighted Average:**
-- Reputers are actors who report on how accurate certain predictions or inferences are against the ground truth.
-- Normally, we might average the accuracy (or "losses") they report, but give more weight to reputers with bigger stakes (more reputation).
+- Reputers are actors who report how accurate certain predictions or inferences are against the ground truth.
+- Normally, we might average the accuracy (or "losses") they report but give more weight to reputers with bigger stakes (more reputation).
 - This means reputers with more stake have more influence on the consensus (agreed-upon truth).
 2. **Runaway Effect:**
 - The problem is that reputers with higher stakes will be closer to consensus, which they have more influence on, and get more rewards, which further increases their stakes.


### PR DESCRIPTION
Closes #54 
Corrected typos and improved grammar in documentation files for better readability and consistency.