### PR TITLE
docs: fix typo build-and-deploy-worker-with-node-runners.mdx

### DIFF
--- a/pages/devs/workers/deploy-worker/build-and-deploy-worker-with-node-runners.mdx
+++ b/pages/devs/workers/deploy-worker/build-and-deploy-worker-with-node-runners.mdx
@@ -45,7 +45,7 @@ This diagram illustrates the architecture of the integration between the Allora 
 
 ## AWS Activate
 
-Before proceeding, please note that eligibility for AWS Activate credits and terams are governed by AWS. This documentation may become outdated, so ensure you refer to the [AWS Activate program page](https://aws.amazon.com/startups/credits#hero) for the latest eligibility requirements and instructions.
+Before proceeding, please note that eligibility for AWS Activate credits and terms are governed by AWS. This documentation may become outdated, so ensure you refer to the [AWS Activate program page](https://aws.amazon.com/startups/credits#hero) for the latest eligibility requirements and instructions.
 
 ## AWS Activate Stepwise Process
 


### PR DESCRIPTION
# Description

I checked all the ‘md’, ‘mdx’ files within the repo. I found a typo and fixed it because it could change the meaning of the document if not fixed.

Fortunately, apart from that, the documentation is well organised and clearly written. Hope this helps and I wish success with the project.

# Changes

"terams" -> "terms"

**Reason:** "Terams" is a typo. The correct spelling is "terms," which refers to the conditions or provisions of an agreement.
