### PR TITLE
Update allora chain repo version from 0.7 to 0.8

### DIFF
--- a/pages/devs/get-started/cli.mdx
+++ b/pages/devs/get-started/cli.mdx
@@ -18,7 +18,7 @@ To install Go, follow one of the recommended methods below or consult the [offic
 ### Installation
 
 ```Text bash
-curl -sSL https://raw.githubusercontent.com/allora-network/allora-chain/main/install.sh | bash -s -- v0.7.0
+curl -sSL https://raw.githubusercontent.com/allora-network/allora-chain/main/install.sh | bash -s -- v0.8.0
 
 ```
 

--- a/pages/marketplace/integrations/goat-sdk.mdx
+++ b/pages/marketplace/integrations/goat-sdk.mdx
@@ -49,12 +49,8 @@ const prediction = await plugin.fetchPricePrediction({
 })
 ```
 
-## Goat
-
-Go out and eat some grass.
-
-[Docs](https://ohmygoat.dev) | [Examples](https://github.com/goat-sdk/goat/tree/main/typescript/examples) | [Discord](https://discord.gg/goat-sdk)
-
-## Goat 🐐
+## About Goat 🐐
 
 Goat 🐐 (Great On-chain Agent Toolkit) is an open-source library enabling AI agents to interact with blockchain protocols and smart contracts via their own wallets.
+
+[Docs](https://ohmygoat.dev) | [Examples](https://github.com/goat-sdk/goat/tree/main/typescript/examples) | [Discord](https://discord.gg/goat-sdk)


### PR DESCRIPTION
faced issue installing allorad 

prev version did not work: 
curl -sSL https://raw.githubusercontent.com/allora-network/allora-chain/main/install.sh | bash -s -- v0.7.0
![image](https://github.com/user-attachments/assets/181eca8d-19f4-41c7-afcb-aa9f4212eed4)

worked:
curl -sSL https://raw.githubusercontent.com/allora-network/allora-chain/main/install.sh | bash -s -- v0.8.0
<img width="848" alt="image" src="https://github.com/user-attachments/assets/a75f7389-f807-4547-a79e-3b43ad2d45ac" />

docs reflect the same updation