### PR TITLE
fix: Fix undeclared variable causing runtime error

### DIFF
--- a/scripts/fixRelativeLinks.js
+++ b/scripts/fixRelativeLinks.js
@@ -63,7 +63,7 @@ async function findAndUpdateLinks(files) {
       let [resolvedPath, fragment] = linkPath.split('#');
       const targetFile = path.resolve(dir, resolvedPath);
 
-      targetFileMDX = targetFile.endsWith('.mdx') ? targetFile : `${targetFile}.mdx`;
+      let targetFileMDX = targetFile.endsWith('.mdx') ? targetFile : `${targetFile}.mdx`;
       if (!fs.existsSync(targetFileMDX)) {
         console.log(`Broken link found in ${file}: ${linkPath} does not exist.`);
         throw new Error('Broken link found');


### PR DESCRIPTION
I noticed that the variable `targetFileMDX` was not declared, which could potentially cause a runtime error. To resolve this, I added the `let` keyword before the variable to ensure it's properly declared.

Now the code should execute without issues related to this variable.
