### PR TITLE
docs(get-started): Fixed broken links in overview for Workers/Validators/Consumers and some of their subsection links ✅

### DIFF
--- a/pages/devs/get-started/overview.mdx
+++ b/pages/devs/get-started/overview.mdx
@@ -1,4 +1,3 @@
-import { Callout } from 'nextra/components'
 
 # Getting Started with Allora
 
@@ -6,73 +5,73 @@ Welcome to the Allora developer's guide! This page will help you get up to speed
 
 ## Overview
 
-Allora is a decentralized network that leverages the power of collective participation in tasks such as data inference, forecasting, and verification. [Contribute](/community/contribute) to any of the repositories below to help enhance and grow the Allora ecosystem.
+Allora is a decentralized network that leverages the power of collective participation in tasks such as data inference, forecasting, and verification. [Contribute](../../community/contribute.mdx) to any of the repositories below to help enhance and grow the Allora ecosystem.
 
 ## Allora Chain
 
 The [Allora chain](https://github.com/allora-network/allora-chain) is a Cosmos Hub chain that forms the core of the Allora network. This repository contains the blockchain's codebase and is useful for validators.
 
-You can use the [`allorad` CLI tool](/devs/get-started/cli#installing-allorad) to query the chain and make transactions.
+You can use the [`allorad` CLI tool](/cli.mdx#installing-allorad) to query the chain and make transactions.
 
 <Callout>
-Some subsections in the Table of Contents below require downloading and installing [`allorad`](/devs/get-started/cli#installing-allorad).
+Some subsections in the Table of Contents below require downloading and installing [`allorad`](./cli.mdx#installing-allorad).
 
 As a general rule, it is suggested to download and install `allorad` for any developer looking to interact with the network.
 </Callout>
 
-## [Setup Wallet](/devs/get-started/setup-wallet.mdx)
+## [Setup Wallet](./setup-wallet.mdx)
 Instructions for setting up your wallet to interact with the Allora network.
 
 ### Subsections
-#### [Basic Usage](/devs/get-started/basic-usage.mdx)
-#### [Existing Topics](/devs/get-started/existing-topics.mdx)
-#### [How to Query Network Data using `allorad`](/devs/get-started/query-network-data.mdx)
+#### [Basic Usage](./basic-usage.mdx)
+#### [Existing Topics](./existing-topics.mdx)
+#### [How to Query Network Data using `allorad`](./query-network-data.mdx)
   
 ---
 
-## [Workers](/devs/workers/workers.mdx)
+## [Workers](../workers/workers.mdx)
 Explore how workers function in Allora, including setup and data querying.
 
 ### Subsections
-#### [System Requirements](/devs/workers/nop-requirements.mdx)
-#### [Build/Deploy an Inference Worker](/devs/workers/deploy-worker.mdx)
-#### [Walkthroughs](/devs/workers/walkthroughs/index.mdx)
-#### [Build and Deploy a Forecaster](/devs/workers/deploy-forecaster.mdx)
-#### [How To Query Worker Data using `allorad`](/devs/workers/query-worker-data.mdx)
-#### [Query EMA Score of a Worker using `allorad`](/devs/workers/query-ema-score.mdx)
+#### [System Requirements](../workers/requirements.mdx)
+#### [Build/Deploy an Inference Worker](../workers/deploy-worker.mdx)
+#### [Walkthroughs](../workers/walkthroughs/index.mdx)
+#### [Build and Deploy a Forecaster](../workers/deploy-forecaster.mdx)
+#### [How To Query Worker Data using `allorad`](../workers/query-worker-data.mdx)
+#### [Query EMA Score of a Worker using `allorad`](../workers/query-ema-score.mdx)
 
 ---
 
-## [Reputers](/devs/reputers/reputers.mdx)
+## [Reputers](../reputers)
 Understand how reputers contribute to reputation management and query operations.
 
 ### Subsections
-#### [Coin Prediction Reputer](/devs/reputers/coin-prediction-reputer.mdx)
-#### [Query EMA Score for a Reputer using `allorad`](/devs/reputers/query-ema-score.mdx)
-#### [Query Reputer Data using `allorad`](/devs/reputers/query-reputer-data.mdx)
-#### [Set and Adjust Stake](/devs/reputers/set-and-adjust-stake.mdx)
+#### [Coin Prediction Reputer](../reputers/coin-prediction-reputer.mdx)
+#### [Query EMA Score for a Reputer using `allorad`](../reputers/query-ema-score.mdx)
+#### [Query Reputer Data using `allorad`](../reputers/query-reputer-data.mdx)
+#### [Set and Adjust Stake](../reputers/set-and-adjust-stake.mdx)
 
 ---
 
-## [Validators](/devs/validators/validators.mdx)
+## [Validators](../validators/validators.mdx)
 Details on how to set up and run a validator in the Allora network.
 
 ### Subsections
-#### [System Requirements](/devs/validators/nop-requirements.mdx)
-#### [Deploy Allora Chain](/devs/validators/deploy-chain.mdx)
-#### [Run a Full Node](/devs/validators/run-full-node.mdx)
-#### [Stake a Validator](/devs/validators/stake-a-validator.mdx)
-#### [Validator Operations](/devs/validators/validator-operations.mdx)
-#### [Software Upgrades](/devs/validators/software-upgrades.mdx)
+#### [System Requirements](../validators/nop-requirements.mdx)
+#### [Deploy Allora Chain](../validators/deploy-chain.mdx)
+#### [Run a Full Node](../validators/run-full-node.mdx)
+#### [Stake a Validator](../validators/stake-a-validator.mdx)
+#### [Validator Operations](../validators/validator-operations.mdx)
+#### [Software Upgrades](../validators/software-upgrades.mdx)
 
 ---
 
-## [Consumers](/devs/consumers/consumers.mdx)
+## [Consumers](../consumers)
 Resources for interacting with Allora as a consumer, including querying data and contracts.
 
 ### Subsections
-#### [Allora API Endpoint](/devs/consumers/allora-api-endpoint.mdx)
-#### [Consumer Contracts](/devs/consumers/consumer-contracts/deploy-consumer.mdx)
-##### [Deploy Consumer Contracts](/devs/consumers/consumer-contracts/dev-consumers.mdx)
-#### [Existing Consumers](/devs/consumers/existing-consumers.mdx)
-#### [Walkthrough: Using a Topic Inference on-chain](/devs/consumers/walkthrough-use-topic-inference.mdx)
+#### [Allora API Endpoint](../consumers/allora-api-endpoint.mdx)
+#### [Consumer Contracts](../consumers/consumer-contracts/deploy-consumer.mdx)
+##### [Deploy Consumer Contracts](../consumers/consumer-contracts/dev-consumers.mdx)
+#### [Existing Consumers](../consumers/existing-consumers.mdx)
+#### [Walkthrough: Using a Topic Inference on-chain](../consumers/walkthrough-use-topic-inference.mdx)

--- a/pages/devs/get-started/overview.mdx
+++ b/pages/devs/get-started/overview.mdx
@@ -33,7 +33,7 @@ Explore how workers function in Allora, including setup and data querying.
 
 ### Subsections
 #### [System Requirements](../workers/requirements.mdx)
-#### [Build/Deploy an Inference Worker](../#builddeploy-an-inference-worker)
+#### [Build/Deploy an Inference Worker](#builddeploy-an-inference-worker)
 #### [Walkthroughs](../workers/walkthroughs/index.mdx)
 #### [Build and Deploy a Forecaster](../workers/deploy-forecaster.mdx)
 #### [How To Query Worker Data using `allorad`](../workers/query-worker-data.mdx)

--- a/pages/devs/get-started/overview.mdx
+++ b/pages/devs/get-started/overview.mdx
@@ -28,7 +28,7 @@ Instructions for setting up your wallet to interact with the Allora network.
   
 ---
 
-## [Workers](../workers/workers.mdx)
+## [Workers](../workers/workers)
 Explore how workers function in Allora, including setup and data querying.
 
 ### Subsections

--- a/pages/devs/get-started/overview.mdx
+++ b/pages/devs/get-started/overview.mdx
@@ -33,7 +33,7 @@ Explore how workers function in Allora, including setup and data querying.
 
 ### Subsections
 #### [System Requirements](../workers/requirements.mdx)
-#### [Build/Deploy an Inference Worker](../workers/deploy-worker.mdx)
+#### [Build/Deploy an Inference Worker](../workers/deploy-worker)
 #### [Walkthroughs](../workers/walkthroughs/index.mdx)
 #### [Build and Deploy a Forecaster](../workers/deploy-forecaster.mdx)
 #### [How To Query Worker Data using `allorad`](../workers/query-worker-data.mdx)

--- a/pages/devs/get-started/overview.mdx
+++ b/pages/devs/get-started/overview.mdx
@@ -33,8 +33,8 @@ Explore how workers function in Allora, including setup and data querying.
 
 ### Subsections
 #### [System Requirements](../workers/requirements.mdx)
-#### [Build/Deploy an Inference Worker](../workers/deploy-worker/_meta.json)
-#### [Walkthroughs](../workers/walkthroughs/index.mdx)
+#### [Build/Deploy an Inference Worker](../workers/deploy-worker/using-docker.mdx)
+#### [Walkthroughs](../workers/walkthroughs/modelpy.mdx)
 #### [Build and Deploy a Forecaster](../workers/deploy-forecaster.mdx)
 #### [How To Query Worker Data using `allorad`](../workers/query-worker-data.mdx)
 #### [Query EMA Score of a Worker using `allorad`](../workers/query-ema-score.mdx)

--- a/pages/devs/get-started/overview.mdx
+++ b/pages/devs/get-started/overview.mdx
@@ -33,7 +33,7 @@ Explore how workers function in Allora, including setup and data querying.
 
 ### Subsections
 #### [System Requirements](../workers/requirements.mdx)
-#### [Build/Deploy an Inference Worker](../workers/##builddeploy-an-inference-worker)
+#### [Build/Deploy an Inference Worker](../workers/deploy-worker/_meta.json)
 #### [Walkthroughs](../workers/walkthroughs/index.mdx)
 #### [Build and Deploy a Forecaster](../workers/deploy-forecaster.mdx)
 #### [How To Query Worker Data using `allorad`](../workers/query-worker-data.mdx)

--- a/pages/devs/get-started/overview.mdx
+++ b/pages/devs/get-started/overview.mdx
@@ -33,7 +33,7 @@ Explore how workers function in Allora, including setup and data querying.
 
 ### Subsections
 #### [System Requirements](../workers/requirements.mdx)
-#### [Build/Deploy an Inference Worker](../workers/deploy-worker)
+#### [Build/Deploy an Inference Worker](../#builddeploy-an-inference-worker)
 #### [Walkthroughs](../workers/walkthroughs/index.mdx)
 #### [Build and Deploy a Forecaster](../workers/deploy-forecaster.mdx)
 #### [How To Query Worker Data using `allorad`](../workers/query-worker-data.mdx)

--- a/pages/devs/get-started/overview.mdx
+++ b/pages/devs/get-started/overview.mdx
@@ -11,11 +11,10 @@ Allora is a decentralized network that leverages the power of collective partici
 
 The [Allora chain](https://github.com/allora-network/allora-chain) is a Cosmos Hub chain that forms the core of the Allora network. This repository contains the blockchain's codebase and is useful for validators.
 
-You can use the [`allorad` CLI tool](/cli.mdx#installing-allorad) to query the chain and make transactions.
+You can use the [`allorad` CLI tool](./cli.mdx#installing-allorad) to query the chain and make transactions.
 
 <Callout>
 Some subsections in the Table of Contents below require downloading and installing [`allorad`](./cli.mdx#installing-allorad).
-
 As a general rule, it is suggested to download and install `allorad` for any developer looking to interact with the network.
 </Callout>
 

--- a/pages/devs/get-started/overview.mdx
+++ b/pages/devs/get-started/overview.mdx
@@ -41,7 +41,7 @@ Explore how workers function in Allora, including setup and data querying.
 
 ---
 
-## [Reputers](../reputers)
+## [Reputers](../reputers.mdx)
 Understand how reputers contribute to reputation management and query operations.
 
 ### Subsections

--- a/pages/devs/get-started/overview.mdx
+++ b/pages/devs/get-started/overview.mdx
@@ -41,7 +41,7 @@ Explore how workers function in Allora, including setup and data querying.
 
 ---
 
-## [Reputers](../reputers)
+## [Reputers](../reputers.mdx)
 Understand how reputers contribute to reputation management and query operations.
 
 ### Subsections
@@ -52,7 +52,7 @@ Understand how reputers contribute to reputation management and query operations
 
 ---
 
-## [Validators](../validators/validators.mdx)
+## [Validators](../validators.mdx)
 Details on how to set up and run a validator in the Allora network.
 
 ### Subsections
@@ -65,7 +65,7 @@ Details on how to set up and run a validator in the Allora network.
 
 ---
 
-## [Consumers](../consumers)
+## [Consumers](../consumers.mdx)
 Resources for interacting with Allora as a consumer, including querying data and contracts.
 
 ### Subsections

--- a/pages/devs/get-started/overview.mdx
+++ b/pages/devs/get-started/overview.mdx
@@ -28,7 +28,7 @@ Instructions for setting up your wallet to interact with the Allora network.
   
 ---
 
-## [Workers](../workers/workers)
+## [Workers](../workers.mdx)
 Explore how workers function in Allora, including setup and data querying.
 
 ### Subsections

--- a/pages/devs/get-started/overview.mdx
+++ b/pages/devs/get-started/overview.mdx
@@ -33,7 +33,7 @@ Explore how workers function in Allora, including setup and data querying.
 
 ### Subsections
 #### [System Requirements](../workers/requirements.mdx)
-#### [Build/Deploy an Inference Worker](../workers/#builddeploy-an-inference-worker)
+#### [Build/Deploy an Inference Worker](../workers/##builddeploy-an-inference-worker)
 #### [Walkthroughs](../workers/walkthroughs/index.mdx)
 #### [Build and Deploy a Forecaster](../workers/deploy-forecaster.mdx)
 #### [How To Query Worker Data using `allorad`](../workers/query-worker-data.mdx)

--- a/pages/devs/get-started/overview.mdx
+++ b/pages/devs/get-started/overview.mdx
@@ -33,7 +33,7 @@ Explore how workers function in Allora, including setup and data querying.
 
 ### Subsections
 #### [System Requirements](../workers/requirements.mdx)
-#### [Build/Deploy an Inference Worker](#builddeploy-an-inference-worker)
+#### [Build/Deploy an Inference Worker](../workers/#builddeploy-an-inference-worker)
 #### [Walkthroughs](../workers/walkthroughs/index.mdx)
 #### [Build and Deploy a Forecaster](../workers/deploy-forecaster.mdx)
 #### [How To Query Worker Data using `allorad`](../workers/query-worker-data.mdx)

--- a/pages/devs/get-started/overview.mdx
+++ b/pages/devs/get-started/overview.mdx
@@ -41,7 +41,7 @@ Explore how workers function in Allora, including setup and data querying.
 
 ---
 
-## [Reputers](../reputers.mdx)
+## [Reputers](../reputers)
 Understand how reputers contribute to reputation management and query operations.
 
 ### Subsections

--- a/pages/devs/get-started/overview.mdx
+++ b/pages/devs/get-started/overview.mdx
@@ -34,7 +34,7 @@ Explore how workers function in Allora, including setup and data querying.
 ### Subsections
 #### [System Requirements](../workers/requirements.mdx)
 #### [Build/Deploy an Inference Worker](../workers/deploy-worker/using-docker.mdx)
-#### [Walkthroughs](../workers/walkthroughs/modelpy.mdx)
+#### [Walkthroughs](../workers/walkthroughs/walkthrough-hugging-face-worker.mdx)
 #### [Build and Deploy a Forecaster](../workers/deploy-forecaster.mdx)
 #### [How To Query Worker Data using `allorad`](../workers/query-worker-data.mdx)
 #### [Query EMA Score of a Worker using `allorad`](../workers/query-ema-score.mdx)


### PR DESCRIPTION
What's Fixed Previously, the Getting Started overview page linked
to the deployment folder, causing navigation issues. This
fix updates the link to point directly at the
correct folders and sections.

- Uses file-level links for 'Using Docker' section instead
  of a folder.
- Improves user experience by opening the correct subpage
  and enabling sidebar highlighting.
- Main sections are now fixed and point out to the correct pages instead of 404 page.
  Fixed: Workers,Reputers,Validators,Consumers