### PR TITLE
improve release notes v0.16.0

### DIFF
--- a/pages/home/release-notes.mdx
+++ b/pages/home/release-notes.mdx
@@ -8,8 +8,11 @@
 #### Math
 - **Regret normalization update**: Regret normalization now uses median absolute deviation (MAD), with adjusted quantiles.
 
-#### Upgrade Maintenance
-- **Keeper refactor and upgrade testing**: Refactored keeper internals and improved upgrade testing.
+#### Maintenance
+- **Upgrade testing**: Improved testing for a more reliable upgrade process.
+
+#### Internal Refactor
+- **Keeper refactor**: a big refactor of the keeper internals.
 
 
 ## v0.15.0


### PR DESCRIPTION
Better description of v0.16.0 release notes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified v0.16.0 release notes for better readability. Renamed "Upgrade Maintenance" to "Maintenance", added an "Internal Refactor" section for the keeper refactor, and tightened the upgrade testing note.

<sup>Written for commit f0c89d232ff58348cedbc4f34d705895d2da1529. Summary will update on new commits. <a href="https://cubic.dev/pr/allora-network/docs/pull/158?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

