### PR TITLE
Update docs to v0.17.0 and fix old incorrections

### DIFF
--- a/pages/devs/consumers/allora-api-endpoint.mdx
+++ b/pages/devs/consumers/allora-api-endpoint.mdx
@@ -45,7 +45,7 @@ API requests are subject to rate limiting. If you exceed the rate limit, you wil
 **Example**: `https://allora-api.testnet.allora.network/emissions/v10/latest_network_inferences/1`
 
 Where:
-- "v10" represents the latest network version number
+- "v10" is the `emissions` API version, which depends on the deployed chain version of the network you are querying (testnet = `v10`, mainnet = `v9`). See [Networks](/devs/reference/networks) for the current version per network.
 - "1" represents the topic ID
 
 An **outlier-resistant** variant is available for single-label regression topics:

--- a/pages/devs/consumers/allora-api-endpoint.mdx
+++ b/pages/devs/consumers/allora-api-endpoint.mdx
@@ -42,93 +42,70 @@ API requests are subject to rate limiting. If you exceed the rate limit, you wil
 
 **Generic**: `https://allora-api.testnet.allora.network/emissions/{version_number}/latest_network_inferences/{topic_id}`
 
-**Example**: `https://allora-api.testnet.allora.network/emissions/v7/latest_network_inferences/1`
+**Example**: `https://allora-api.testnet.allora.network/emissions/v10/latest_network_inferences/1`
 
 Where:
-- "v7" represents the latest network version number
+- "v10" represents the latest network version number
 - "1" represents the topic ID
 
-Sample Response:
+An **outlier-resistant** variant is available for single-label regression topics:
+
+**Outlier-resistant**: `https://allora-api.testnet.allora.network/emissions/v10/latest_network_inferences_outlier_resistant/{topic_id}`
+
+Sample Response (single-output regression topic):
 
 ```json
 {
   "network_inferences": {
     "topic_id": "1",
-    "reputer_request_nonce": null,
-    "reputer": "",
-    "extra_data": null,
-    "combined_value": "2605.533879185080648394998043723508",
+    "nonce": "1349577",
+    "combined_value": [
+      { "label_id": 1, "label_name": "y", "value": "2605.533879185080648394998043723508" }
+    ],
     "inferer_values": [
       {
         "worker": "allo102ksu3kx57w0mrhkg37kvymmk2lgxqcan6u7yn",
-        "value": "2611.01109296"
+        "values": [
+          { "label_id": 1, "label_name": "y", "value": "2611.01109296" }
+        ]
       },
       {
         "worker": "allo10q6hm2yae8slpvvgmxqrcasa30gu5qfysp4wkz",
-        "value": "2661.505295679922"
+        "values": [
+          { "label_id": 1, "label_name": "y", "value": "2661.505295679922" }
+        ]
       }
     ],
     "forecaster_values": [
-        {
-            "worker": "allo1za8r9v0st4ntfyeka23qs5wvd7mvsnzhztupk0",
-            "value": "2610.160000000000000000000000000000"
-        }
+      {
+        "worker": "allo1za8r9v0st4ntfyeka23qs5wvd7mvsnzhztupk0",
+        "values": [
+          { "label_id": 1, "label_name": "y", "value": "2610.160000000000000000000000000000" }
+        ]
+      }
     ],
-    "naive_value": "2605.533879185080648394998043723508",
+    "naive_value": [
+      { "label_id": 1, "label_name": "y", "value": "2605.533879185080648394998043723508" }
+    ],
     "one_out_inferer_values": [
       {
-        "worker": "allo102ksu3kx57w0mrhkg37kvymmk2lgxqcan6u7yn",
-        "value": "2570.859434973857748387096774193548"
-      },
-      {
-        "worker": "allo10q6hm2yae8slpvvgmxqrcasa30gu5qfysp4wkz",
-        "value": "2569.230589724828006451612903225806"
+        "withheld_inferer": "allo102ksu3kx57w0mrhkg37kvymmk2lgxqcan6u7yn",
+        "combined_inference": [
+          { "label_id": 1, "label_name": "y", "value": "2570.859434973857748387096774193548" }
+        ]
       }
     ],
     "one_out_forecaster_values": [],
     "one_in_forecaster_values": [],
     "one_out_inferer_forecaster_values": []
   },
-  "inferer_weights": [
-    {
-      "worker": "allo102ksu3kx57w0mrhkg37kvymmk2lgxqcan6u7yn",
-      "weight": "0.0002191899319465528034563075461505151"
-    },
-    {
-      "worker": "allo10q6hm2yae8slpvvgmxqrcasa30gu5qfysp4wkz",
-      "weight": "0.0002191899319465528034563075461505151"
-    }
-  ],
-  "forecaster_weights": [
-    {
-      "worker": "allo1za8r9v0st4ntfyeka23qs5wvd7mvsnzhztupk0",
-      "weight": "0.1444137067859501612197657742201029"
-    }
-  ],
-  "forecast_implied_inferences": [
-    {
-      "worker": "allo1za8r9v0st4ntfyeka23qs5wvd7mvsnzhztupk0",
-      "value": "2610.160000000000000000000000000000"
-    }
-  ],
-  "inference_block_height": "1349577",
-  "loss_block_height": "0",
-  "confidence_interval_raw_percentiles": [
-    "2.28",
-    "15.87",
-    "50",
-    "84.13",
-    "97.72"
-  ],
-  "confidence_interval_values": [
-    "2492.1675618299669694181830608795809",
-    "2543.9249467952655499150756965734158",
-    "2611.033130351115229549044053766836",
-    "2662.29523395638446190095015123294396",
-    "2682.827040221238"
-  ]
+  "inference_block_height": "1349577"
 }
 ```
+
+<Callout type="info">
+Since v0.17.0 the network inference is returned as a **labeled bundle**. Every value carries a `label_id` and `label_name`. A **single-output** topic (like the one above) always uses the canonical label `y`, so each array holds a single entry. A **multi-output / classification** topic returns one entry per label — for example `combined_value` might contain `{ "label_name": "up", ... }`, `{ "label_name": "down", ... }`, and `{ "label_name": "flat", ... }`.
+</Callout>
 
 <Callout type="warning">
 Please be aware that there may be some expected volatility in predictions due to the nascency of the network and the more forgiving testnet configurations currently in place. We are actively working on implementing an outlier protection mechanism, which will be applied at the consumer layer and tailored to individual use cases in the near future.
@@ -136,44 +113,43 @@ Please be aware that there may be some expected volatility in predictions due to
 
 ## Breaking Down the Response
 
-Below is an explanation of important sub-objects displayed in the JSON output:
+Below is an explanation of the important fields in the JSON output. Every inference value is **labeled** (`label_id` + `label_name` + `value`); single-output topics use the canonical label `y`.
 
 ### `topic_id`
 In this case, "1" represents the topic being queried. [Topics](/devs/topic-creators/how-to-create-topic) define the context and rules for a particular inference.
 
-### `naive_value`
-The **naive value** omits all forecast-implied inferences from the weighted average by setting their weights to zero. The naive network inference is used to quantify the contribution of the
-forecasting task to the network accuracy, which in turn sets the reward distribution between the inference and forecasting tasks.
-
 ### `combined_value`
-The **combined value** is an optimized inference that represents a collective intelligence approach, taking both naive submissions and forecast data into account.
+The **combined value** is an optimized inference that represents a collective intelligence approach, taking both worker submissions and forecast data into account.
 
-> If you are looking to just get one value or number from Allora for a data oracle, this would be the one to take.
+> If you are looking to just get one value or number from Allora for a data oracle, this is the one to take (for a single-output topic, the entry labeled `y`).
 
 ### `inferer_values`
-Workers in the network submit their inferences, each represented by an `allo` address. For example:
+Workers in the network submit their inferences, each represented by an `allo` address and one value per label. For example:
 
 ```json
 {
     "worker": "allo102ksu3kx57w0mrhkg37kvymmk2lgxqcan6u7yn",
-    "value": "2611.01109296"
+    "values": [
+        { "label_id": 1, "label_name": "y", "value": "2611.01109296" }
+    ]
 }
 ```
 
-Each worker submits a value based on their own models. These individual submissions contribute to both the naive and combined values. The combined value gives higher weighting to more reliable workers, based on performance or other criteria.
+Each worker submits values based on their own models. These individual submissions contribute to both the naive and combined values. The combined value gives higher weighting to more reliable workers, based on performance or other criteria.
 
-### `one_out_inferer_values`
-These values simulate removing a single worker from the pool to see how the overall inference changes. This is a technique used to evaluate the impact of individual inferences on the combined result. 
+### `forecaster_values`
+The forecast-implied inferences, one per forecaster. A [forecast-implied inference](/home/layers/forecast-synthesis/synthesis#forecast-implied-inferences) uses forecasted losses and worker inferences to produce a predicted value, weighted by how accurately each forecaster predicted losses in previous epochs.
 
-### `forecast_implied_inferences`
-The [Forecast-Implied Inference](/home/layers/forecast-synthesis/synthesis#forecast-implied-inferences) uses forecasted losses and worker inferences to produce a predicted value where each prediction is weighted based on how accurately the forecasters predicted losses in previous time steps, or epochs.
+### `naive_value`
+The **naive value** omits all forecast-implied inferences from the weighted average by setting their weights to zero. It is used to quantify the contribution of the forecasting task to network accuracy, which in turn sets the reward distribution between the inference and forecasting tasks.
+
+### `one_out_inferer_values` / `one_out_forecaster_values` / `one_in_forecaster_values`
+These simulate removing (or adding) a single participant to measure their marginal impact on the combined inference. They are used for scoring and reward distribution.
 
 ### `inference_block_height`
-The specific chain block that the inference data was generated
+The specific chain block at which the inference data was generated.
 
-### `confidence_interval_raw_percentiles`
-Fixed percentiles that are used to generate [confidence intervals](/home/confidence-intervals)
-
-### `confidence_interval_values`
-[Confidence intervals](/home/confidence-intervals) show the predicted range of outcomes based on worker inferences.
+<Callout type="info">
+Per-actor **weights** and **confidence intervals** are not part of this response. Weights can be queried separately (for example `GetLatestInfererWeight` / `GetLatestForecasterWeight`), and confidence intervals are described on the [Confidence Intervals](/home/confidence-intervals) page.
+</Callout>
 

--- a/pages/devs/consumers/rpc-data-access.mdx
+++ b/pages/devs/consumers/rpc-data-access.mdx
@@ -17,7 +17,6 @@ Each network uses a different RPC URL and Chain ID which are needed to specify w
 
 ### Testnet
 - **RPC URLs**:
-  - `https://rpc.ankr.com/allora_testnet`
   - `https://allora-rpc.testnet.allora.network/`
 - **Chain ID**: `allora-testnet-1`
 

--- a/pages/devs/consumers/rpc-data-access.mdx
+++ b/pages/devs/consumers/rpc-data-access.mdx
@@ -25,55 +25,56 @@ Each network uses a different RPC URL and Chain ID which are needed to specify w
 
 The following RPC methods are particularly useful for consumers looking to access inference data from the Allora network:
 
-### Get Latest Available Network Inferences
+### Get Latest Network Inferences
 
 This is the primary method for consumers to retrieve the latest network inference for a specific topic.
 
 ```bash
-allorad q emissions latest-available-network-inferences [topic_id] --node <RPC_URL>
+allorad q emissions latest-network-inferences [topic_id] --node <RPC_URL>
 ```
 
 **Parameters:**
-- `topic_id`: The identifier of the topic for which you want to retrieve the latest available network inference.
+- `topic_id`: The identifier of the topic for which you want to retrieve the latest network inference.
 - `RPC_URL`: The URL of the RPC node you're connecting to.
 
 **Example:**
 ```bash
-allorad q emissions latest-available-network-inferences 1 --node https://allora-rpc.testnet.allora.network/
+allorad q emissions latest-network-inferences 1 --node https://allora-rpc.testnet.allora.network/
 ```
 
+An **outlier-resistant** variant (single-label regression topics only) is available via `allorad q emissions latest-network-inferences-outlier-resistant [topic_id]`.
+
 **Response:**
-The response includes the network inference data, including the combined value, individual worker values, confidence intervals, and more. Here's a simplified example:
+The response includes the network inference bundle — the combined value, individual worker values, a naive baseline, and one-out/one-in values. Since v0.17.0 every value is **labeled**; single-output topics use the canonical label `y`. Here's a simplified example:
 
 ```json
 {
   "network_inferences": {
     "topic_id": "1",
-    "combined_value": "2605.533879185080648394998043723508",
+    "nonce": "1349577",
+    "combined_value": [
+      { "label_id": 1, "label_name": "y", "value": "2605.533879185080648394998043723508" }
+    ],
     "inferer_values": [
       {
         "worker": "allo102ksu3kx57w0mrhkg37kvymmk2lgxqcan6u7yn",
-        "value": "2611.01109296"
+        "values": [ { "label_id": 1, "label_name": "y", "value": "2611.01109296" } ]
       },
       {
         "worker": "allo10q6hm2yae8slpvvgmxqrcasa30gu5qfysp4wkz",
-        "value": "2661.505295679922"
+        "values": [ { "label_id": 1, "label_name": "y", "value": "2661.505295679922" } ]
       }
     ],
-    "naive_value": "2605.533879185080648394998043723508"
+    "naive_value": [
+      { "label_id": 1, "label_name": "y", "value": "2605.533879185080648394998043723508" }
+    ]
   },
-  "confidence_interval_values": [
-    "2492.1675618299669694181830608795809",
-    "2543.9249467952655499150756965734158",
-    "2611.033130351115229549044053766836",
-    "2662.29523395638446190095015123294396",
-    "2682.827040221238"
-  ]
+  "inference_block_height": "1349577"
 }
 ```
 
 <Callout type="info">
-The `combined_value` field represents the optimized inference that takes both naive submissions and forecast data into account. This is typically the value you want to use for most consumer applications.
+The `combined_value` field is a list of labeled values representing the optimized inference that takes both worker submissions and forecast data into account. For a single-output topic it holds a single entry (labeled `y`), which is typically the value you want for most consumer applications. A multi-output / classification topic returns one entry per label.
 </Callout>
 
 ## Using RPC in Your Applications
@@ -92,7 +93,7 @@ async function getLatestInference(topicId: number, rpcUrl: string) {
       id: 1,
       method: 'abci_query',
       params: {
-        path: `/allora.emissions.v1.Query/GetLatestAvailableNetworkInferences`,
+        path: `/allora.emissions.v10.Query/GetLatestNetworkInferences`,
         data: Buffer.from(JSON.stringify({ topic_id: topicId })).toString('hex'),
         prove: false
       }
@@ -118,8 +119,9 @@ async function getLatestInference(topicId: number, rpcUrl: string) {
 // Example usage
 getLatestInference(1, 'https://allora-rpc.testnet.allora.network/')
   .then(data => {
-    console.log('Latest inference:', data.network_inferences.combined_value);
-    console.log('Confidence intervals:', data.confidence_interval_values);
+    // combined_value is a list of labeled values; a single-output topic has one entry ("y")
+    console.log('Latest inference:', data.network_inferences.combined_value[0].value);
+    console.log('Inference block height:', data.inference_block_height);
   })
   .catch(error => {
     console.error('Failed to get inference:', error);
@@ -142,7 +144,7 @@ def get_latest_inference(topic_id, rpc_url):
             "id": 1,
             "method": "abci_query",
             "params": {
-                "path": "/allora.emissions.v1.Query/GetLatestAvailableNetworkInferences",
+                "path": "/allora.emissions.v10.Query/GetLatestNetworkInferences",
                 "data": bytes(json.dumps({"topic_id": topic_id}), 'utf-8').hex(),
                 "prove": False
             }
@@ -167,8 +169,9 @@ def get_latest_inference(topic_id, rpc_url):
 # Example usage
 try:
     data = get_latest_inference(1, "https://allora-rpc.testnet.allora.network/")
-    print(f"Latest inference: {data['network_inferences']['combined_value']}")
-    print(f"Confidence intervals: {data['confidence_interval_values']}")
+    # combined_value is a list of labeled values; a single-output topic has one entry ("y")
+    print(f"Latest inference: {data['network_inferences']['combined_value'][0]['value']}")
+    print(f"Inference block height: {data['inference_block_height']}")
 except Exception as e:
     print(f"Failed to get inference: {e}")
 ```

--- a/pages/devs/get-started/setup-wallet.mdx
+++ b/pages/devs/get-started/setup-wallet.mdx
@@ -48,6 +48,5 @@ Each network uses a different RPC URL and Chain ID which are needed to specify w
 
 - **Testnet**
     - `RPC_URL`:  
-        - https://rpc.ankr.com/allora_testnet
         - https://allora-rpc.testnet.allora.network/
     - `CHAIN_ID`: `allora-testnet-1`

--- a/pages/devs/reference/_meta.json
+++ b/pages/devs/reference/_meta.json
@@ -1,4 +1,5 @@
 {
+    "networks": "Networks",
     "allorad": "allorad",
     "module-accounts": "Module Accounts",
     "params": "Parameters"

--- a/pages/devs/reference/allorad.mdx
+++ b/pages/devs/reference/allorad.mdx
@@ -1,3 +1,5 @@
+import { Callout } from 'nextra/components'
+
 # `allorad` Reference
 
 `allorad` commands below are broken out into: 
@@ -578,12 +580,16 @@ allorad q emissions [Command] --node <RPC_URL>
 - **Description:** Get the total amount of staked tokens by all participants in the network.
 
 ### Get the Latest Inference for a Given Worker and Topic
-- **RPC Method:** `GetWorkerLatestInference`
-- **Command:** `worker-latest-inference [topic_id] [worker_address]`
-- **Description:** Get the latest inference for a given worker and topic.
+- **RPC Method:** `GetWorkerLatestInputInferenceByTopicId`
+- **Command:** `latest-input-inference [topic_id] [worker_address]`
+- **Description:** Get the latest inference submitted by a given worker for a topic. Returns an `InputInference` (the worker's submitted payload, including its labeled `values`).
 - **Positional Arguments:**
   - `topic_id` Identifier of the topic whose information will be returned
   - `worker_address` Given worker to query on
+
+<Callout type="info">
+In v0.17.0 this query was renamed from `GetWorkerLatestInference` (`worker-latest-inference`) to `GetWorkerLatestInputInferenceByTopicId` (`latest-input-inference`), and now returns an `InputInference` instead of a dense `Inference`. The REST path is `/emissions/v10/topics/{topic_id}/workers/{worker_address}/latest_input_inference`.
+</Callout>
 
 ## Tx Functions
 
@@ -595,24 +601,57 @@ allorad tx emissions [Command]
 
 ### Create New Topic
 - **RPC Method:** `CreateNewTopic`
-- **Command:** `create-topic [creator] [metadata] [loss_logic] [loss_method] [inference_logic] [inference_method] [epoch_length] [ground_truth_lag] [default_arg] [p_norm] [alpha_regret] [allow_negative] [tolerance]`
+- **Command:** `create-topic [creator] [metadata] [loss_method] [epoch_length] [ground_truth_lag] [worker_submission_window] [p_norm] [alpha_regret] [allow_negative] [epsilon] [merit_sortition_alpha] [active_inferer_quantile] [active_forecaster_quantile] [active_reputer_quantile] [enable_worker_whitelist] [enable_reputer_whitelist] [c_norm] [topic_type] [output_arity] [require_unity] [unity_tolerance] [max_labels_per_submission] [label_whitelist] [label_default_value] [label_case_sensitive]`
 - **Description:** Add a new topic to the network.
 - **Positional Arguments:**
   - `creator` The creator is the owner of the topic that is able to update the topic in the future
   - `metadata`
-  - `loss_logic`
   - `loss_method`
-  - `inference_logic`
-  - `inference_method`
   - `epoch_length`
   - `ground_truth_lag`
-  - `default_arg`
+  - `worker_submission_window`
   - `p_norm`
   - `alpha_regret`
   - `allow_negative`
-  - `tolerance`
+  - `epsilon`
+  - `merit_sortition_alpha`
+  - `active_inferer_quantile`
+  - `active_forecaster_quantile`
+  - `active_reputer_quantile`
+  - `enable_worker_whitelist`
+  - `enable_reputer_whitelist`
+  - `c_norm`
+  - `topic_type` — `1` = regression, `2` = classification
+  - `output_arity` — `1` = single output, `2` = multiple labeled outputs
+  - `require_unity` — classification only: require per-label outputs to sum to one
+  - `unity_tolerance`
+  - `max_labels_per_submission`
+  - `label_whitelist` — JSON array of permitted labels; `'[]'` means unrestricted
+  - `label_default_value`
+  - `label_case_sensitive` — immutable after creation
 
 Detailed instructions on [how to create a topic](/devs/topic-creators/how-to-create-topic) are linked.
+
+### Update Topic
+- **RPC Method:** `UpdateTopic`
+- **Command:** `update-topic [sender] [topic_id] [metadata] [loss_method] [alpha_regret] [merit_sortition_alpha] [p_norm] [c_norm] [max_labels_per_submission] [label_whitelist] [label_default_value]`
+- **Description:** Update an existing topic's modifiable configuration. Only the topic creator may do so. `topic_type`, `output_arity`, `require_unity` and `label_case_sensitive` are fixed at creation.
+- **Positional Arguments:**
+  - `sender` Must be the topic creator
+  - `topic_id`
+  - `metadata`
+  - `loss_method`
+  - `alpha_regret`
+  - `merit_sortition_alpha`
+  - `p_norm`
+  - `c_norm`
+  - `max_labels_per_submission`
+  - `label_whitelist` — full replacement; an empty list sets the topic to unrestricted
+  - `label_default_value`
+
+<Callout type="warning">
+`update-topic` performs a **full replacement** of the fields it accepts. In particular, sending an empty `label_whitelist` sets the topic to *unrestricted* rather than preserving the current list. Label changes are rejected while a worker submission window is open for the topic.
+</Callout>
 
 ### Add an Admin Address to the Whitelist
 - **RPC Method:** `AddToWhitelistAdmin`

--- a/pages/devs/reference/networks.mdx
+++ b/pages/devs/reference/networks.mdx
@@ -14,7 +14,7 @@ the production **mainnet**. Each may run a different `allora-chain` version, whi
 | **Chain ID** | `allora-testnet-1` | `allora-mainnet-1` |
 | **Deployed version** | v0.17.0 | v0.16.0 |
 | **Emissions API namespace** | `emissions/v10` | `emissions/v9` |
-| **RPC** | `https://allora-rpc.testnet.allora.network/`<br/>`https://rpc.ankr.com/allora_testnet` | `https://allora-rpc.mainnet.allora.network/` |
+| **RPC** | `https://allora-rpc.testnet.allora.network/` | `https://allora-rpc.mainnet.allora.network/` |
 | **API (REST)** | `https://allora-api.testnet.allora.network/` | `https://allora-api.mainnet.allora.network/` |
 | **Explorer** | `https://explorer.testnet.allora.network/allora-testnet-1` | `https://explorer.allora.network/` |
 
@@ -32,7 +32,6 @@ and the [Release Notes](/home/release-notes).
 - **Deployed version**: v0.17.0 (serves the `emissions/v10` API)
 - **RPC**:
   - `https://allora-rpc.testnet.allora.network/`
-  - `https://rpc.ankr.com/allora_testnet`
 - **API (REST)**: `https://allora-api.testnet.allora.network/`
 - **Explorer**: `https://explorer.testnet.allora.network/allora-testnet-1`
 - **Faucet / wallet setup**: see [Setup Wallet](/devs/get-started/setup-wallet)

--- a/pages/devs/reference/networks.mdx
+++ b/pages/devs/reference/networks.mdx
@@ -14,8 +14,9 @@ the production **mainnet**. Each may run a different `allora-chain` version, whi
 | **Chain ID** | `allora-testnet-1` | `allora-mainnet-1` |
 | **Deployed version** | v0.17.0 | v0.16.0 |
 | **Emissions API namespace** | `emissions/v10` | `emissions/v9` |
-| **RPC** | `https://allora-rpc.testnet.allora.network/` | `https://allora-rpc.mainnet.allora.network/` |
-| **API (REST)** | `https://allora-api.testnet.allora.network/` | `https://allora-api.mainnet.allora.network/` |
+| **RPC JSON** | `https://allora-rpc.testnet.allora.network/` | `https://allora-rpc.mainnet.allora.network/` |
+| **gRPC** | `https://allora-grpc.testnet.allora.network/` | `https://allora-grpc.mainnet.allora.network/` |
+| **API (Cosmos LCD - REST)** | `https://allora-api.testnet.allora.network/` | `https://allora-api.mainnet.allora.network/` |
 | **Explorer** | `https://explorer.testnet.allora.network/allora-testnet-1` | `https://explorer.allora.network/` |
 
 <Callout type="warning">
@@ -30,9 +31,9 @@ and the [Release Notes](/home/release-notes).
 
 - **Chain ID**: `allora-testnet-1`
 - **Deployed version**: v0.17.0 (serves the `emissions/v10` API)
-- **RPC**:
-  - `https://allora-rpc.testnet.allora.network/`
-- **API (REST)**: `https://allora-api.testnet.allora.network/`
+- **RPC JSON**: `https://allora-rpc.testnet.allora.network/`
+- **gRPC**: `https://allora-grpc.testnet.allora.network/`
+- **API (Cosmos LCD - REST)**: `https://allora-api.testnet.allora.network/`
 - **Explorer**: `https://explorer.testnet.allora.network/allora-testnet-1`
 - **Faucet / wallet setup**: see [Setup Wallet](/devs/get-started/setup-wallet)
 
@@ -43,8 +44,9 @@ before they ship to mainnet.
 
 - **Chain ID**: `allora-mainnet-1`
 - **Deployed version**: v0.16.0 (serves the `emissions/v9` API)
-- **RPC**: `https://allora-rpc.mainnet.allora.network/`
-- **API (REST)**: `https://allora-api.mainnet.allora.network/`
+- **RPC JSON**: `https://allora-rpc.mainnet.allora.network/`
+- **gRPC**: `https://allora-grpc.mainnet.allora.network/`
+- **API (Cosmos LCD - REST)**: `https://allora-api.mainnet.allora.network/`
 - **Explorer**: `https://explorer.allora.network/`
 
 <Callout type="info">
@@ -57,6 +59,6 @@ Pick the version segment that matches the network you are querying.
 ## Related
 
 - [Allora API Endpoint](/devs/consumers/allora-api-endpoint) — querying inferences over REST
-- [RPC Data Access](/devs/consumers/rpc-data-access) — querying over RPC
-- [Setup Wallet](/devs/get-started/setup-wallet) — RPC URL and Chain ID configuration
+- [RPC JSON Data Access](/devs/consumers/rpc-data-access) — querying over RPC JSON
+- [Setup Wallet](/devs/get-started/setup-wallet) — RPC JSON URL and Chain ID configuration
 - [Software Upgrades](/devs/validators/software-upgrades) — how network versions are upgraded

--- a/pages/devs/reference/networks.mdx
+++ b/pages/devs/reference/networks.mdx
@@ -1,0 +1,63 @@
+import { Callout } from 'nextra/components'
+
+# Networks
+
+> Chain IDs, endpoints, and the currently deployed `allora-chain` version for each Allora network.
+
+The Allora Network runs as two public networks: a **testnet** for development and integration, and
+the production **mainnet**. Each may run a different `allora-chain` version, which also determines the
+`emissions` REST/gRPC API version (for example, v0.16.x serves `emissions/v9` while v0.17.x serves
+`emissions/v10`).
+
+| | Testnet | Mainnet |
+|---|---|---|
+| **Chain ID** | `allora-testnet-1` | `allora-mainnet-1` |
+| **Deployed version** | v0.17.0 | v0.16.0 |
+| **Emissions API namespace** | `emissions/v10` | `emissions/v9` |
+| **RPC** | `https://allora-rpc.testnet.allora.network/`<br/>`https://rpc.ankr.com/allora_testnet` | `https://allora-rpc.mainnet.allora.network/` |
+| **API (REST)** | `https://allora-api.testnet.allora.network/` | `https://allora-api.mainnet.allora.network/` |
+| **Explorer** | `https://explorer.testnet.allora.network/allora-testnet-1` | `https://explorer.allora.network/` |
+
+<Callout type="warning">
+Deployed versions change with each [software upgrade](/devs/validators/software-upgrades). Testnet is
+typically upgraded ahead of mainnet, so features from a newer release (such as the v0.17.0 multi-label
+and labeled network-inference APIs) may be available on testnet before they reach mainnet. Always
+confirm against the [allora-chain releases](https://github.com/allora-network/allora-chain/releases)
+and the [Release Notes](/home/release-notes).
+</Callout>
+
+## Testnet
+
+- **Chain ID**: `allora-testnet-1`
+- **Deployed version**: v0.17.0 (serves the `emissions/v10` API)
+- **RPC**:
+  - `https://allora-rpc.testnet.allora.network/`
+  - `https://rpc.ankr.com/allora_testnet`
+- **API (REST)**: `https://allora-api.testnet.allora.network/`
+- **Explorer**: `https://explorer.testnet.allora.network/allora-testnet-1`
+- **Faucet / wallet setup**: see [Setup Wallet](/devs/get-started/setup-wallet)
+
+Use the testnet for building and testing integrations, running workers/reputers, and trying features
+before they ship to mainnet.
+
+## Mainnet
+
+- **Chain ID**: `allora-mainnet-1`
+- **Deployed version**: v0.16.0 (serves the `emissions/v9` API)
+- **RPC**: `https://allora-rpc.mainnet.allora.network/`
+- **API (REST)**: `https://allora-api.mainnet.allora.network/`
+- **Explorer**: `https://explorer.allora.network/`
+
+<Callout type="info">
+The `emissions` API version differs by network. On mainnet (v0.16.0) network-inference endpoints live
+under `emissions/v9` and return a single (unlabeled) value; on testnet (v0.17.0) they live under
+`emissions/v10` and return [labeled network-inference bundles](/devs/consumers/allora-api-endpoint).
+Pick the version segment that matches the network you are querying.
+</Callout>
+
+## Related
+
+- [Allora API Endpoint](/devs/consumers/allora-api-endpoint) — querying inferences over REST
+- [RPC Data Access](/devs/consumers/rpc-data-access) — querying over RPC
+- [Setup Wallet](/devs/get-started/setup-wallet) — RPC URL and Chain ID configuration
+- [Software Upgrades](/devs/validators/software-upgrades) — how network versions are upgraded

--- a/pages/devs/reference/params/chain.mdx
+++ b/pages/devs/reference/params/chain.mdx
@@ -161,3 +161,25 @@ Default Value: 0.0000001
 The maximum length of a string to allow to store on the chain. For example, used in limiting metadata for the creation of new topics.
 
 Default Value: 255
+
+## Multi-Label Parameters
+
+These parameters (introduced in v0.17.0) bound the size of the [label registry](/devs/topic-creators/how-to-create-topic#topic-types-output-arity-and-labels) used by multi-output topics.
+
+#### max_canonical_label_byte_length
+
+The maximum byte length of a canonical label name, after NFC normalization and whitespace trimming.
+
+Default Value: 64
+
+#### max_topic_label_whitelist_size
+
+The maximum number of canonical labels allowed in a single topic's label whitelist.
+
+Default Value: 256
+
+#### max_epoch_label_registry_size
+
+The maximum number of labels allowed in an epoch label registry for a single (topic, nonce).
+
+Default Value: 32768

--- a/pages/devs/reputers.mdx
+++ b/pages/devs/reputers.mdx
@@ -15,7 +15,7 @@ This ground truth is essential for evaluating the accuracy of inferences made by
 
 Reputers calculate the loss of worker inferences and forecast-implied inferences relative to the ground truth. 
 
-For instance, if a topic's [loss function](/devs/topic-creators/create-deploy-loss-calculation-function) is an L1-norm, reputers apply this norm to each worker's inference and the actual price of ETH in 10 days. 
+For instance, if a topic's [loss function](/devs/topic-creators/how-to-create-topic) is an L1-norm, reputers apply this norm to each worker's inference and the actual price of ETH in 10 days. 
 They then respond with a [`ValueBundle` of losses](https://github.com/allora-network/allora-chain/blob/1d56c50c8d0f43446d770cf387dbd43bb3613e8c/x/emissions/proto/emissions/v1/reputer.proto#L28), detailing the calculated losses for each inference.
 
 ### Secure Topics with Stake

--- a/pages/devs/topic-creators/how-to-create-topic.mdx
+++ b/pages/devs/topic-creators/how-to-create-topic.mdx
@@ -1,3 +1,5 @@
+import { Callout } from 'nextra/components'
+
 # How to Create a Topic
 
 > Inferences for the same domain are aggregated into the same topic
@@ -57,32 +59,71 @@ type MsgCreateNewTopic struct {
   ActiveInfererQuantile github_com_allora_network_allora_chain_math.Dec `json:"active_inferer_quantile"`
   ActiveForecasterQuantile github_com_allora_network_allora_chain_math.Dec `json:"active_forecaster_quantile"`
   ActiveReputerQuantile github_com_allora_network_allora_chain_math.Dec `json:"active_reputer_quantile"`
+  // Restrict inference/forecast submissions to whitelisted workers
+  EnableWorkerWhitelist bool `json:"enable_worker_whitelist,omitempty"`
+  // Restrict loss submissions to whitelisted reputers
+  EnableReputerWhitelist bool `json:"enable_reputer_whitelist,omitempty"`
+  // Per-topic normalization constant used when mapping regrets to weights
+  CNorm            github_com_allora_network_allora_chain_math.Dec `json:"c_norm"`
+  // --- Multi-label / classification (added in v0.17.0) ---
+  // Topic type: 1 = TOPIC_TYPE_REGRESSION, 2 = TOPIC_TYPE_CLASSIFICATION
+  TopicType        TopicType `json:"topic_type,omitempty"`
+  // Output arity: 1 = TOPIC_OUTPUT_ARITY_SINGLE, 2 = TOPIC_OUTPUT_ARITY_MULTI
+  OutputArity      TopicOutputArity `json:"output_arity,omitempty"`
+  // For classification topics: require the per-label outputs to sum to one
+  RequireUnity     bool `json:"require_unity,omitempty"`
+  // Tolerance applied to the unity (sum-to-one) constraint
+  UnityTolerance   github_com_allora_network_allora_chain_math.Dec `json:"unity_tolerance"`
+  // Cap on the number of labels a single worker may submit in one payload (multi-output topics)
+  MaxLabelsPerSubmission uint64 `json:"max_labels_per_submission,omitempty"`
+  // Optional allowlist of permitted (canonicalized) label names; empty means unrestricted
+  LabelWhitelist   []string `json:"label_whitelist,omitempty"`
+  // Default value used for missing label slots in dense multi-label vectors
+  LabelDefaultValue github_com_allora_network_allora_chain_math.Dec `json:"label_default_value"`
+  // If false (default), label names are lowercased when canonicalized ("Cat" == "cat");
+  // immutable after topic creation
+  LabelCaseSensitive bool `json:"label_case_sensitive,omitempty"`
 }
 ```
 
 Using the [`allorad` CLI](/devs/get-started/cli#installing-allorad) to create a topic:
 
+The command takes the following positional arguments, in order:
+
 ```shell bash
 allorad tx emissions create-topic \
-  allo13tr5nx74zjdh7ya8kgyuu0hweppnnx8d4ux7pj \    # Creator address
-  "ETH prediction in 24h" \                                         # Metadata
-  "mse" \                                         # LossMethod
-  3600 \                                          # EpochLength
-  0 \                                             # GroundTruthLag
-  3 \                                             # WorkerSubmissionWindow
-  3 \                                             # PNorm 
-  1 \                                             # AlphaRegret 
-  true \                                          # AllowNegative
-  0.001 \                                         # Epsilon
-  0.1 \                                           # MeritSortitionAlpha
-  0.25 \                                           # ActiveInfererQuantile
-  0.25 \                                           # ActiveForecasterQuantile
-  0.25 \                                           # ActiveReputerQuantile
-  --node <RPC_URL>
+  allo13tr5nx74zjdh7ya8kgyuu0hweppnnx8d4ux7pj \    # creator address
+  "ETH prediction in 24h" \                        # metadata
+  "mse" \                                          # loss_method
+  3600 \                                           # epoch_length
+  0 \                                              # ground_truth_lag
+  3 \                                              # worker_submission_window
+  3 \                                              # p_norm
+  1 \                                              # alpha_regret
+  true \                                           # allow_negative
+  0.001 \                                          # epsilon
+  0.1 \                                            # merit_sortition_alpha
+  0.25 \                                           # active_inferer_quantile
+  0.25 \                                           # active_forecaster_quantile
+  0.25 \                                           # active_reputer_quantile
+  false \                                          # enable_worker_whitelist
+  false \                                          # enable_reputer_whitelist
+  0.75 \                                           # c_norm
+  1 \                                              # topic_type (1 = regression)
+  1 \                                              # output_arity (1 = single output)
+  false \                                          # require_unity
+  0 \                                              # unity_tolerance
+  1 \                                              # max_labels_per_submission
+  '[]' \                                           # label_whitelist (empty = unrestricted)
+  0 \                                              # label_default_value
+  false \                                          # label_case_sensitive
+  --node <RPC_URL> \
   --chain-id <CHAIN_ID>
 ```
 
 Be sure to swap out [`RPC_URL`](/devs/get-started/setup-wallet#rpc-url-and-chain-id), `YOUR_ADDRESS`, [`CHAIN_ID`](/devs/get-started/setup-wallet#rpc-url-and-chain-id) and all other arguments as appropriate with the desired values.
+
+The example above creates a standard **single-output regression topic** — the historical default, and what most price/quantity prediction topics use. The last nine arguments (`enable_worker_whitelist` through `label_case_sensitive`) configure whitelisting and the multi-label features introduced in v0.17.0; see the section below.
 
 ### Notes
 
@@ -92,6 +133,42 @@ An explanation in more detail of some of these fields.
 - `allowNegative` determines whether the loss function output can be negative.
   - If **true**, the reputer submits raw losses.
   - If **false**, the reputer submits logs of losses.
+
+## Topic Types, Output Arity, and Labels
+
+Starting in **v0.17.0**, a topic declares what kind of output it produces. These fields are set at
+creation and, except for the label registry, cannot be changed afterwards.
+
+- **`topic_type`** — `1` for **regression** (numeric prediction, e.g. the price of ETH) or `2` for
+  **classification** (predicting the likelihood of discrete outcomes).
+- **`output_arity`** — `1` for a **single** output value, or `2` for **multiple** labeled outputs. A
+  single-output topic behaves exactly like topics did before v0.17.0.
+- **`require_unity`** / **`unity_tolerance`** — for classification topics, require the per-label
+  outputs to sum to one (a probability distribution), within `unity_tolerance`.
+
+Multi-output topics attach a **label** to each value a worker submits (for example `up`, `down`,
+`flat`). The topic's **label registry** controls this:
+
+- **`max_labels_per_submission`** — the maximum number of labels a single worker may include in one
+  payload.
+- **`label_whitelist`** — an optional allowlist of permitted label names. Leave it empty (`'[]'`) to
+  accept any label; provide a list (e.g. `'["up","down","flat"]'`) to restrict submissions. Labels
+  are canonicalized (UTF-8, NFC-normalized, trimmed) before comparison.
+- **`label_default_value`** — the value used for label slots a worker omits when building the dense
+  multi-label vector.
+- **`label_case_sensitive`** — when `false` (the default), `Cat`, `CAT` and `cat` collapse to the
+  same label; when `true` they are distinct. This flag is immutable after creation.
+
+A single-output topic internally uses the canonical label `y`, which is why single-output network
+inferences are still returned under a single value.
+
+<Callout type="info">
+`update-topic` performs a **full replacement** of the fields it accepts (including the label
+registry). In particular, sending an empty `label_whitelist` sets the topic to *unrestricted* rather
+than preserving the current list, so always re-send the full whitelist to keep a restriction. Label
+changes are rejected while a worker submission window is open. `topic_type`, `output_arity`,
+`require_unity` and `label_case_sensitive` cannot be changed after creation.
+</Callout>
 
 ---
 

--- a/pages/devs/topic-creators/how-to-create-topic.mdx
+++ b/pages/devs/topic-creators/how-to-create-topic.mdx
@@ -123,7 +123,7 @@ allorad tx emissions create-topic \
 
 Be sure to swap out [`RPC_URL`](/devs/get-started/setup-wallet#rpc-url-and-chain-id), `YOUR_ADDRESS`, [`CHAIN_ID`](/devs/get-started/setup-wallet#rpc-url-and-chain-id) and all other arguments as appropriate with the desired values.
 
-The example above creates a standard **single-output regression topic** — the historical default, and what most price/quantity prediction topics use. The last nine arguments (`enable_worker_whitelist` through `label_case_sensitive`) configure whitelisting and the multi-label features introduced in v0.17.0; see the section below.
+The example above creates a standard **single-output regression topic** — the historical default, and what most price/quantity prediction topics use. The last eleven arguments (`enable_worker_whitelist` through `label_case_sensitive`) configure whitelisting and the multi-label features introduced in v0.17.0; see the section below.
 
 ### Notes
 

--- a/pages/devs/validators/deploy-chain.mdx
+++ b/pages/devs/validators/deploy-chain.mdx
@@ -39,7 +39,7 @@ Once this is set up, run `docker compose up`.
 ## Deploy in k8s with helm chart
 
 Upshot team uses a [universal-helm](https://upshot-tech.github.io/helm-charts/) chart to deploy applications into kubernetes clusters.  
-There is a `index-provider/values.yaml` provided that sets up one head node and one worker node.
+There is an `index-provider/values.yaml` provided as an example that sets up the node components.
 
 ### Dependencies
 

--- a/pages/devs/validators/nop-requirements.mdx
+++ b/pages/devs/validators/nop-requirements.mdx
@@ -29,6 +29,6 @@ The topic-specific logic ran by validators is compiled to WASM and stored on IPF
 - Inferences from the past epoch
 - The revealed ground truth consisting of up to `topic.inference_cadence/topic.loss_cadence`-many values. In other words, it entails one ground truth value for each inference cadence within the preceding loss-calculation epoch.
 
-The WASM also involves committing the new losses to the appchain in a transaction. This is ultimately done by one b7s node.
+The new losses are then committed to the appchain in a transaction.
 
 Computing loss-calculation logic off-chain saves the network validators operating expenses (because less is run on-chain), allows topic creators to write loss-calculation logic in any language (that compiles to WASM), and lessens the need for frequent node software upgrades (because the module source code remains unchanged even as new topics are added, each with their specific loss-calculation schemes).

--- a/pages/devs/workers/deploy-worker/build-and-deploy-worker-with-node-runners.mdx
+++ b/pages/devs/workers/deploy-worker/build-and-deploy-worker-with-node-runners.mdx
@@ -17,7 +17,7 @@ This diagram illustrates the architecture of the integration between the Allora 
 #### Key Components
 
 1. **Allora Network (Cosmos AppChain)**
-   - **Public Head Node**: Acts as the entry point for the Allora Network, handling requests and responses.
+   - **Allora appchain**: The entry point for the Allora Network, coordinating topics, worker submissions, and network inferences.
 
 2. **AWS Account Setup**
    - **Region**: The geographical location within AWS where the resources are deployed.
@@ -33,7 +33,7 @@ This diagram illustrates the architecture of the integration between the Allora 
 #### Process Flow
 
 1. **Request Flow**:
-   - The Allora Network's Public Head Node sends a request for inferences to the EC2 instance within the AWS environment.
+   - The Allora appchain triggers a request for inferences to the EC2 instance within the AWS environment.
    - The request passes through the VPC Internet Gateway and reaches the Offchain node in the public subnet.
    - The Offchain node forwards the request to the Node Function.
    - The Node Function calls `Main.py` on the Model Server to generate the required inferences.

--- a/pages/devs/workers/query-worker-data.mdx
+++ b/pages/devs/workers/query-worker-data.mdx
@@ -55,13 +55,15 @@ allorad q emissions [Command] --node <RPC_URL>
 
 ## Get Latest Worker Inference By Topic ID
 
-- **RPC Method:** `GetWorkerLatestInferenceByTopicId`
-- **Command:** `worker-latest-inference [topic_id] [worker_address]`
-- **Description:** Gets the latest inference for a given worker and topic.
+- **RPC Method:** `GetWorkerLatestInputInferenceByTopicId`
+- **Command:** `latest-input-inference [topic_id] [worker_address]`
+- **Description:** Gets the latest inference submitted by a given worker for a topic. Since v0.17.0 this returns an `InputInference` — the worker's submitted payload, including its labeled `values`.
 
 - **Positional Arguments:**
   - `topic_id` Identifier of the topic whose information will be returned
   - `worker_address` Given worker to query on
+
+> In v0.17.0 this query was renamed from `GetWorkerLatestInferenceByTopicId` (`worker-latest-inference`) to `GetWorkerLatestInputInferenceByTopicId` (`latest-input-inference`).
 
 ### Use Case
 **Why use it?**

--- a/pages/home/key-terms.mdx
+++ b/pages/home/key-terms.mdx
@@ -14,6 +14,19 @@ Loss calculation logic determined at topic creation by a topic creator who decid
 - The loss function to use (e.g., mean absolute directional loss, L1-norm)
 - The source of ground truth (e.g., some endpoint, some oracle, the median of gathered inferences)
 
+### Topic Types
+
+Since v0.17.0, a topic declares the kind of output it produces:
+
+- **Regression topics** predict a numeric value (e.g. the future price of ETH).
+- **Classification topics** predict the likelihood of discrete outcomes, and can optionally require those outcomes to sum to one (a probability distribution).
+
+A topic also declares its **output arity** — whether it produces a **single** value or **multiple** labeled values (see Labels).
+
+### Labels
+
+Names attached to the individual values a worker submits to a **multi-output** topic (for example `up`, `down`, `flat`). Each topic maintains a **label registry** and may restrict the permitted labels via an allowlist, cap how many labels a worker may submit, and define a default value for omitted labels. Single-output topics use one canonical label (`y`) internally.
+
 ## Inferences
 
 Predictions or conclusions made by workers about specific outcomes within a given topic. 
@@ -34,6 +47,10 @@ An additional dimension of evaluation that enables the network to achieve the be
 By incorporating feedback from the test set (live, revealed ground truth plus the live, revealed performances of one's peers), both inference and forecast models of individual workers can be improved over time. This improves overall network performance. 
 
 By incentivizing forecasts, workers are incentivized to understand the contexts in which they and their peers perform well or poorly. For example, forecasters may understand that a subset of workers perform better on Wednesdays, whereas another performs well on Thursdays, or some do well in bear markets and others in bull markets. Integrating such context-aware insights empowers Allora to admit better performance than any individual actor because it can selectively leverage insights from the appropriate actors in the appropriate contexts.
+
+## Network Inference
+
+The network's aggregate output for a topic in a given epoch — a weighted combination of the individual worker inferences and forecast-implied inferences. It is stored on-chain and served to consumers as a **network inference bundle** containing the combined value, the contributing inferer and forecaster values, a naive baseline, and one-out/one-in values used for scoring. Since v0.17.0 every value in the bundle is **labeled**, so multi-output topics return one value per label while single-output topics return a single value under the canonical label `y`. An optional **outlier-resistant** variant is produced for single-label regression topics.
 
 ## Network Participants
 

--- a/pages/home/layers/forecast-synthesis/synthesis.mdx
+++ b/pages/home/layers/forecast-synthesis/synthesis.mdx
@@ -45,3 +45,11 @@ This combined result is expected to be more accurate and reliable due to the wei
 
 ![synthesis-final](/synthesis-final.jpg)
 
+## Multi-Label Topics
+
+Since v0.17.0, synthesis is **label-aware**. For [multi-output topics](/devs/topic-creators/how-to-create-topic#topic-types-output-arity-and-labels), the process above runs independently for each label, and the result is returned as a **network inference bundle** — a set of labeled values rather than a single number. A single-output topic is simply the special case with one canonical label (`y`), so its bundle carries a single value.
+
+For **classification** topics that set `require_unity`, the per-label outputs are constrained to sum to one (within the topic's `unity_tolerance`), so the bundle represents a probability distribution across the labels.
+
+The **outlier-resistant** network inference is only computed for single-label regression topics; it is not produced for multi-label topics.
+

--- a/pages/home/release-notes.mdx
+++ b/pages/home/release-notes.mdx
@@ -1,6 +1,33 @@
 # Allora Network Release Notes
 
 
+## v0.17.0
+
+### Key Features and Improvements
+
+#### Topics
+- **Multi-label & classification topics**: Topics can now be typed as regression or classification (`topic_type`) and emit either a single value or a vector of labeled outputs (`output_arity`). Multi-output topics carry a per-topic label registry, with an optional `label_whitelist`, a `max_labels_per_submission` cap, a `label_default_value` for sparse submissions, and an immutable `label_case_sensitive` flag.
+- **Classification unity constraint**: Classification topics can require their per-label outputs to sum to one (`require_unity`) within a configurable `unity_tolerance`.
+- **New topic & module parameters**: `create-topic`/`update-topic` accept the new label-registry fields, and three new module params bound label sizes (`max_canonical_label_byte_length`, `max_topic_label_whitelist_size`, `max_epoch_label_registry_size`).
+
+#### Network Inference
+- **Labeled network inferences**: Network inferences are now stored and served as a `NetworkInferenceBundle` of labeled values, supporting multi-label topics. Single-output topics use a canonical `y` label.
+- **Unified event**: A single `EventNetworkInferenceBundle` (with an `outlier_resistant` flag) replaces the separate network-inference and outlier-resistant events.
+- **Outlier-resistant scope**: Outlier-resistant network inferences are computed only for single-label regression topics; the outlier-resistant query now returns an error for multi-label topics.
+
+#### Queries and CLI (breaking)
+- **v10 emissions API**: Emissions queries and transactions move to the `emissions/v10` package and REST namespace.
+- **Worker latest-inference query renamed**: `GetWorkerLatestInferenceByTopicId` → `GetWorkerLatestInputInferenceByTopicId` (REST `.../latest_input_inference`), now returning an `InputInference`.
+- **Wider p_norm range**: The allowed `p_norm` range for topics was increased.
+
+### Bug Fixes and Other Improvements
+- **AutoCLI**: Fixed parameter advertising, fixed dry-run and auto-gas handling, and added keyring simulation.
+- **Events**: Clamp `Dec` magnitudes in emissions events to keep event payloads compact.
+
+### Upgrade
+- **v0.17.0 upgrade**: The `x/emissions` consensus version is bumped to 15. The migration backfills regression/single-output defaults on existing topics and converts stored network inferences to the new labeled bundle format.
+
+
 ## v0.16.0
 
 ### Key Features and Improvements


### PR DESCRIPTION
## Update docs for allora-chain v0.17.0

Documents **multi-label & classification topics** and **labeled network inference**, adds v0.17.0 release notes, and cleans up some legacy "blockless"-era content. Grounded in the real `v0.16.0..v0.17.0` diff (v10 protos, `autocli.go`, REST paths).

### Changes
- **Release notes**: new `## v0.17.0` entry.
- **New features**: topic-creation guide (new topic/label fields + full CLI), key terms, inference synthesis, consumer API/RPC pages (labeled responses, `v7`→`v10`), and reference pages (`allorad`, chain params, worker query).
- **Safe fixes**: removed `b7s`/"head node" wording; fixed a broken link.
- **`CLEANUP_PLAN.md`**: audit of remaining stale content for a follow-up pass.

### Notes
- **Breaking**: emissions moves to `emissions/v10`, worker latest-inference query renamed, network inferences are now labeled bundles.
- Verified statically (links, anchors, imports); Nextra build not run locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates docs for `allora-chain` v0.17.0: adds multi-label/classification topics, labeled network inference bundles, and `emissions/v10` REST/RPC updates. Adds a Networks reference with chain IDs and RPC/gRPC/REST endpoints per network; removes Ankr URLs and legacy wording to meet ENGN-8849.

- **New Features**
  - v0.17.0 release notes; new Networks page with chain IDs, RPC/gRPC/REST endpoints, and per-network `emissions` version (testnet `v10`, mainnet `v9`).
  - Multi-label/classification topics and label registry; expanded `create-topic`/`update-topic` docs and new chain params.
  - Labeled network inference bundles over REST/RPC, plus outlier-resistant variant (single-label regression only); examples updated and weights/confidence intervals moved out of the response.
  - `allorad` reference: `emissions/v10` paths, worker query renamed to `latest-input-inference` (returns `InputInference`), and `latest-network-inferences` (+ outlier-resistant).

- **Migration**
  - Switch to `emissions/v10` and `GetLatestNetworkInferences`/`latest-network-inferences` (was `latest-available-network-inferences`); responses are labeled arrays (single-output uses label `y`).
  - Use outlier-resistant endpoints only for single-label regression topics.
  - Replace `worker-latest-inference` with `latest-input-inference` (returns `InputInference`).
  - Pick the `emissions` version by network (testnet `v10`, mainnet `v9`); per-actor weights and confidence intervals are no longer in the network-inference response.

<sup>Written for commit 7705a81f627dba964aad7262f53f692aad623d70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allora-network/docs/pull/164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

