### PR TITLE
Network version drift: update public/api/networks.json

### DIFF
--- a/public/api/networks.json
+++ b/public/api/networks.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2026-07-31",
+  "updated": "2026-08-15",
   "docs": "https://docs.allora.network/reference/networks",
   "field_notes": {
     "chain_id": "Cosmos SDK chain ID to pass to allorad and wallet software.",
@@ -24,8 +24,11 @@
       "lcd": "https://allora-api.testnet.allora.network/",
       "explorer": "https://explorer.testnet.allora.network/allora-testnet-1",
       "faucet": "https://faucet.testnet.allora.network/",
-      "sandbox_topic_ids": [69, 77],
-      "abci_version": "HEAD-ac7ae1565bda7266fd741515e09faccf85bc8af1"
+      "sandbox_topic_ids": [
+        69,
+        77
+      ],
+      "abci_version": "HEAD-b6104eda6b2b009ea0714d2f724d53f4f0365fc0"
     },
     "mainnet": {
       "name": "Mainnet",


### PR DESCRIPTION
The scheduled network drift check found that at least one Allora network is
reporting a different build over RPC than `public/api/networks.json` records.

| Network | RPC | Recorded `abci_version` | Reported by `abci_info` |
|---|---|---|---|
| testnet | `https://allora-rpc.testnet.allora.network/abci_info` | `HEAD-ac7ae1565bda7266fd741515e09faccf85bc8af1` | `HEAD-b6104eda6b2b009ea0714d2f724d53f4f0365fc0` |

This PR updates `abci_version` for the networks above.

The `deployed_version` release tag is **not** changed automatically: `abci_info`
reports a build identifier rather than a release tag. Check the
[allora-chain releases](https://github.com/allora-network/allora-chain/releases)
and, if a new release is live, update `deployed_version` (and the
`emissions_namespace` if the upgrade bumped the emissions module) in this PR
before merging.

If you do change `deployed_version`, change the matching `chain_<network>` key
in `public/api/versions.json` in the same commit — `yarn checkversions` fails
while the two files disagree.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns testnet `abci_version` in `public/api/networks.json` with the RPC-reported build to resolve network version drift. Previously this value was out of sync; now it matches the node’s `abci_info`. No runtime behavior changes.

- Only testnet changed; `deployed_version` and `emissions_namespace` are unchanged.
- If a new release tag corresponds to this build, update `deployed_version` for testnet and the matching `chain_testnet` key in `public/api/versions.json` in the same commit to keep version checks passing.

<sup>Written for commit c8c4633f3e21aec98628e344bd175b0623b73048. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allora-network/docs/pull/182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

